### PR TITLE
[MS-331] Update Storage Return Path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 
+generated-outputs/bookmarks/*
 generated-outputs/databases/*
 generated-outputs/results/*
 generated-outputs/runners/*

--- a/io-modules/jsonio.py
+++ b/io-modules/jsonio.py
@@ -21,23 +21,21 @@ class JsonIO(IOInterface):
 
     def create_file(self, data: dict) -> bool:
         """
-        Creates a JSON file at the specified path with the provided data.
+        Writes the provided data to a JSON file located at the path specified during object initialization.
+
+        This method serializes the given dictionary into JSON format and writes it to the file.
+        If the file does not exist, it will be created. If the file already exists, its contents will be overwritten.
 
         Args:
-            data (dict): The data to serialize into JSON format and write to the file.
+            data (dict): The data to be serialized into JSON and written to the file.
 
         Returns:
-            bool: True if the file creation was successful, False otherwise.
+            bool: Always returns True to indicate the operation was executed without raising an exception.
         """
-        try:
-            with open(self.json_path, "w") as json_file:
-                json.dump(data, json_file, indent=2, ensure_ascii=False)
-            return True
-        except Exception as e:
-            logger.error(
-                f"[JsonIO] Error creating JSON file ({self.json_path}) - {str(e)}"
-            )
-            return False
+        with open(self.json_path, "w") as json_file:
+            json.dump(data, json_file, indent=2, ensure_ascii=False)
+        
+        return True
 
     def read_file(self) -> dict | None:
         """


### PR DESCRIPTION
## Description

Update the creation of object to return the path instead of a boolean so that we can update the users on where the object is created if required.

## Motivation and Context

QOL improvement

## Type of Change

<!-- Select the appropriate type of change: -->
A new feature

## How to Test

1. Start Moonshot in CLI.` python -m moonshot cli interactive`
2. [Positive case] Enter `export_bookmarks`. You should see the exported bookmarks path in your CLI
3. [Negative case] Rename the `bookmarks` folder to something else. Run the `export_bookmarks` command again. You should see a `[ERROR] ... Failed to export bookmarks` error printed out by the logger.


## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- []  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [x]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>