### PR TITLE
[MS-432] Fix range bug

### DIFF
--- a/runners-modules/benchmarking.py
+++ b/runners-modules/benchmarking.py
@@ -723,11 +723,11 @@ class Benchmarking:
             self.num_of_prompts == 0
             or self.num_of_prompts > ds_args.num_of_dataset_prompts
         ):
-            prompt_indices = range(1, ds_args.num_of_dataset_prompts + 1)
+            prompt_indices = range(ds_args.num_of_dataset_prompts)
         else:
             random.seed(self.random_seed)
             prompt_indices = random.sample(
-                range(1, ds_args.num_of_dataset_prompts + 1), self.num_of_prompts
+                range(ds_args.num_of_dataset_prompts), self.num_of_prompts
             )
         logger.debug(
             f"[Benchmarking] Dataset {ds_id}, using {len(prompt_indices)} of {ds_args.num_of_dataset_prompts} prompts."


### PR DESCRIPTION
## Description

AdvGLUE recipe has: 
0 prompt template 
1 dataset with 721 prompts 
User input 200, ran 199

Winobias recipe has: 
0 prompt template 
1 dataset with 396 prompts 
User input 200, ran 199

## Motivation and Context

This is a range bug. There are 2 issues found. 

When user types 20 prompts, the dataset has 5. By right it should range from 0, 1, 2, 3, 4. But the error will do a range 1, 2, 3, 4, 5, it will skip the first prompt and have an issue with index on the last value. Hence 4/5.

When user types 3 prompts and the dataset has 5. By right it should contain exactly 3 unique numbers from the set {0, 1, 2, 3, 4}. But the error will have a range will contain exactly 3 unique numbers from the set {1, 2, 3, 4, 5} where 5 is invalid and missing the first index.

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

Run easy test with 200 prompts

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)
<img width="1215" alt="Screenshot 2024-08-20 at 9 13 39 PM" src="https://github.com/user-attachments/assets/4bba48c5-a88b-4542-ad46-1a3fa4922dc3">
<img width="1223" alt="Screenshot 2024-08-20 at 9 13 25 PM" src="https://github.com/user-attachments/assets/a3620f38-f039-4e1b-8aaa-f08b72e7a33f">
<img width="1205" alt="Screenshot 2024-08-20 at 9 13 33 PM" src="https://github.com/user-attachments/assets/e22e176d-bde5-4492-86c5-701355be78cb">

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>