### PR TITLE
[MS-477] return metric config

### DIFF
--- a/metrics/advglue.py
+++ b/metrics/advglue.py
@@ -15,6 +15,8 @@ class AdvGlueExactMatch(MetricInterface):
             "a prompt with minimal changes."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -25,15 +27,13 @@ class AdvGlueExactMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the AdvGlueExactMatch class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/advglue.py
+++ b/metrics/advglue.py
@@ -27,7 +27,6 @@ class AdvGlueExactMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the AdvGlueExactMatch class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/bertscore.py
+++ b/metrics/bertscore.py
@@ -30,7 +30,6 @@ class BertScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the BertScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/bertscore.py
+++ b/metrics/bertscore.py
@@ -18,6 +18,8 @@ class BertScore(MetricInterface):
         self.name = "BertScore"
         self.description = "BertScore uses Bert to check for the similarity in embedding between two sentences."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -28,15 +30,13 @@ class BertScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the BertScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/bleuscore.py
+++ b/metrics/bleuscore.py
@@ -25,7 +25,6 @@ class BleuScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the BleuScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/bleuscore.py
+++ b/metrics/bleuscore.py
@@ -13,6 +13,8 @@ class BleuScore(MetricInterface):
         self.name = "BleuScore"
         self.description = "Bleuscore uses Bleu to return the various rouge scores."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -23,15 +25,13 @@ class BleuScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the BleuScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/cache.json
+++ b/metrics/cache.json
@@ -5,7 +5,7 @@
     "description": "BertScore uses Bert to check for the similarity in embedding between two sentences.",
     "endpoints": [],
     "configurations": {},
-    "hash": "cf3f9f59005e6ac9"
+    "hash": "e55e7df7ec8735c4"
   },
   "spelling": {
     "id": "spelling",
@@ -13,7 +13,7 @@
     "description": "SpellingScore uses Levenshetein Distance to find permutations within an edit distance of 2 form the original word before comparing to known words in a word frequency list.",
     "endpoints": [],
     "configurations": {},
-    "hash": "3c4420533db67036"
+    "hash": "68b552cc27e4b0c2"
   },
   "gpt4annotator": {
     "id": "gpt4annotator",
@@ -23,7 +23,7 @@
       "llm-judge-openai-gpt4-annotator"
     ],
     "configurations": {},
-    "hash": "7de5e0a0c8ee7c0c"
+    "hash": "070c51134449f405"
   },
   "bleuscore": {
     "id": "bleuscore",
@@ -31,7 +31,7 @@
     "description": "Bleuscore uses Bleu to return the various rouge scores.",
     "endpoints": [],
     "configurations": {},
-    "hash": "55aced8609377cdd"
+    "hash": "a8ef57585b6f42fd"
   },
   "readabilityscore": {
     "id": "readabilityscore",
@@ -39,7 +39,7 @@
     "description": "ReadabilityScore uses Flesch Reading Ease to compute the complexity of the output",
     "endpoints": [],
     "configurations": {},
-    "hash": "03996b376517baac"
+    "hash": "36d70de4b49df802"
   },
   "toxicity-classifier": {
     "id": "toxicity-classifier",
@@ -47,7 +47,7 @@
     "description": "This classifier measures how toxic a given input isand calculate the number of toxic sentence detected.",
     "endpoints": [],
     "configurations": {},
-    "hash": "3567cf9d503db702"
+    "hash": "7a5de681e8fc449c"
   },
   "rougescorer": {
     "id": "rougescorer",
@@ -55,7 +55,7 @@
     "description": "RougeScorer returns the various rouge scores.",
     "endpoints": [],
     "configurations": {},
-    "hash": "4aaf39a5761c46fa"
+    "hash": "7f6ed108f03e9ef2"
   },
   "advglue": {
     "id": "advglue",
@@ -63,7 +63,7 @@
     "description": "Attack success rate measures how successful a changed prompt performs. A high score shows that the system under test is highly sensitive towards a prompt with minimal changes.",
     "endpoints": [],
     "configurations": {},
-    "hash": "e0df20e672c254c4"
+    "hash": "e210403c8c3b2685"
   },
   "leakagerate": {
     "id": "leakagerate",
@@ -71,7 +71,7 @@
     "description": "Leakage Rate will compare the LCS between two string - Output and Target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "6b488f7f1a259836"
+    "hash": "1497969180615161"
   },
   "reverseexactstrmatch": {
     "id": "reverseexactstrmatch",
@@ -79,7 +79,7 @@
     "description": "ReverseExactStrMatch will compare the output from language model with the expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "22756e249619c124"
+    "hash": "9ec28ac9a87e74bb"
   },
   "exactstrmatch": {
     "id": "exactstrmatch",
@@ -87,7 +87,7 @@
     "description": "ExactStrMatch will compare the output from language model with a single target or multiple expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "35879fb447e74e5c"
+    "hash": "b9f176af6d4574f2"
   },
   "relaxstrmatch": {
     "id": "relaxstrmatch",
@@ -95,7 +95,7 @@
     "description": "RelaxStrMatch will remove symbols and spaces before comparing the output from language model with the expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "caac223e662d7daf"
+    "hash": "8563a3afda2fbf85"
   },
   "llamaguardannotator": {
     "id": "llamaguardannotator",
@@ -105,7 +105,7 @@
       "together-llama-guard-7b-assistant"
     ],
     "configurations": {},
-    "hash": "dda6b201d2ba2802"
+    "hash": "98b8c9f55a66e73b"
   },
   "samplemetric": {
     "id": "samplemetric",
@@ -119,17 +119,17 @@
       "threshold_value": "0.35",
       "num_of_prompts_to_calculate": 1
     },
-    "hash": "6e77e93044025e6e"
+    "hash": "1aee488080e952ba"
   },
   "lionguardclassifier": {
     "id": "lionguardclassifier",
     "name": "LionGuard Classifier",
     "description": "This classifier measures how unsafe a given input is in the Singapore context.\nIt can calculate the number of toxic sentences detected. ",
-    "endpoints": null,
+    "endpoints": [],
     "configurations": {
       "grading_classifier": "toxic"
     },
-    "hash": "4a2e56f3b2dd5e23"
+    "hash": "de375b2a7aa3e99e"
   },
   "flagjudgeannotator": {
     "id": "flagjudgeannotator",
@@ -139,7 +139,7 @@
       "flageval-flagjudge"
     ],
     "configurations": {},
-    "hash": "c7d9fb829fc625d0"
+    "hash": "cba9ee0cf5bcd74a"
   },
   "q16_metric": {
     "id": "q16_metric",
@@ -147,7 +147,7 @@
     "description": "Q16 is a binary classifier used to determine whether an image is inappropriate (https://github.com/ml-research/Q16)",
     "endpoints": [],
     "configurations": {},
-    "hash": "bd6b450dc92e5395"
+    "hash": "905858ed425bf66a"
   },
   "nudenet_metric": {
     "id": "nudenet_metric",
@@ -155,7 +155,7 @@
     "description": "NudeNet is a classifier used to deduce probabilities of exposed body parts in images.",
     "endpoints": [],
     "configurations": {},
-    "hash": "d46766cd42d0a97e"
+    "hash": "610863c7b9431c44"
   },
   "genderbias_metric": {
     "id": "genderbias_metric",
@@ -163,6 +163,6 @@
     "description": "This metric uses a CLIP based gender classifier to determine the proportion of females returning a score between 0 and 0.5. score = |female_frac - 0.5|",
     "endpoints": [],
     "configurations": {},
-    "hash": "eabd08a995abff85"
+    "hash": "8f4fc691d5ef51d3"
   }
 }

--- a/metrics/cache.json
+++ b/metrics/cache.json
@@ -5,7 +5,7 @@
     "description": "BertScore uses Bert to check for the similarity in embedding between two sentences.",
     "endpoints": [],
     "configurations": {},
-    "hash": "81a2e96ed6b2f064"
+    "hash": "cf3f9f59005e6ac9"
   },
   "spelling": {
     "id": "spelling",
@@ -13,7 +13,7 @@
     "description": "SpellingScore uses Levenshetein Distance to find permutations within an edit distance of 2 form the original word before comparing to known words in a word frequency list.",
     "endpoints": [],
     "configurations": {},
-    "hash": "f02d6358b8bcb14b"
+    "hash": "3c4420533db67036"
   },
   "gpt4annotator": {
     "id": "gpt4annotator",
@@ -23,7 +23,7 @@
       "llm-judge-openai-gpt4-annotator"
     ],
     "configurations": {},
-    "hash": "e7fbc254f1e5a5c8"
+    "hash": "7de5e0a0c8ee7c0c"
   },
   "bleuscore": {
     "id": "bleuscore",
@@ -31,7 +31,7 @@
     "description": "Bleuscore uses Bleu to return the various rouge scores.",
     "endpoints": [],
     "configurations": {},
-    "hash": "ce3e7884ee162578"
+    "hash": "55aced8609377cdd"
   },
   "readabilityscore": {
     "id": "readabilityscore",
@@ -39,7 +39,7 @@
     "description": "ReadabilityScore uses Flesch Reading Ease to compute the complexity of the output",
     "endpoints": [],
     "configurations": {},
-    "hash": "786470c5a6143af5"
+    "hash": "03996b376517baac"
   },
   "toxicity-classifier": {
     "id": "toxicity-classifier",
@@ -47,7 +47,7 @@
     "description": "This classifier measures how toxic a given input isand calculate the number of toxic sentence detected.",
     "endpoints": [],
     "configurations": {},
-    "hash": "6623b4c60bab200f"
+    "hash": "3567cf9d503db702"
   },
   "rougescorer": {
     "id": "rougescorer",
@@ -55,7 +55,7 @@
     "description": "RougeScorer returns the various rouge scores.",
     "endpoints": [],
     "configurations": {},
-    "hash": "7439d49cfcc567ee"
+    "hash": "4aaf39a5761c46fa"
   },
   "advglue": {
     "id": "advglue",
@@ -63,7 +63,7 @@
     "description": "Attack success rate measures how successful a changed prompt performs. A high score shows that the system under test is highly sensitive towards a prompt with minimal changes.",
     "endpoints": [],
     "configurations": {},
-    "hash": "30f5bb95d3788e10"
+    "hash": "e0df20e672c254c4"
   },
   "leakagerate": {
     "id": "leakagerate",
@@ -71,7 +71,7 @@
     "description": "Leakage Rate will compare the LCS between two string - Output and Target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "98d4f2dfc61ff7aa"
+    "hash": "6b488f7f1a259836"
   },
   "reverseexactstrmatch": {
     "id": "reverseexactstrmatch",
@@ -79,7 +79,7 @@
     "description": "ReverseExactStrMatch will compare the output from language model with the expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "e8d1edf5e1414d99"
+    "hash": "22756e249619c124"
   },
   "exactstrmatch": {
     "id": "exactstrmatch",
@@ -87,7 +87,7 @@
     "description": "ExactStrMatch will compare the output from language model with a single target or multiple expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "6f0aca34dd51ab9e"
+    "hash": "35879fb447e74e5c"
   },
   "relaxstrmatch": {
     "id": "relaxstrmatch",
@@ -95,7 +95,7 @@
     "description": "RelaxStrMatch will remove symbols and spaces before comparing the output from language model with the expected target.",
     "endpoints": [],
     "configurations": {},
-    "hash": "8ac72775345b6bb2"
+    "hash": "caac223e662d7daf"
   },
   "llamaguardannotator": {
     "id": "llamaguardannotator",
@@ -105,7 +105,7 @@
       "together-llama-guard-7b-assistant"
     ],
     "configurations": {},
-    "hash": "234d2fd54dcc4b7d"
+    "hash": "dda6b201d2ba2802"
   },
   "samplemetric": {
     "id": "samplemetric",
@@ -119,23 +119,27 @@
       "threshold_value": "0.35",
       "num_of_prompts_to_calculate": 1
     },
-    "hash": "22438c30060f69d8"
+    "hash": "6e77e93044025e6e"
   },
   "lionguardclassifier": {
     "id": "lionguardclassifier",
     "name": "LionGuard Classifier",
     "description": "This classifier measures how unsafe a given input is in the Singapore context.\nIt can calculate the number of toxic sentences detected. ",
-    "endpoints": [],
-    "configurations": {},
-    "hash": "f18c14bf15ae45fe"
+    "endpoints": null,
+    "configurations": {
+      "grading_classifier": "toxic"
+    },
+    "hash": "4a2e56f3b2dd5e23"
   },
   "flagjudgeannotator": {
     "id": "flagjudgeannotator",
     "name": "FlagJudge Annotator",
     "description": "Calculates the number of correct response using FlagJudge (A judge model from FlagEval Group).",
-    "endpoints": [],
+    "endpoints": [
+      "flageval-flagjudge"
+    ],
     "configurations": {},
-    "hash": "c5a0783e8ee605dc"
+    "hash": "c7d9fb829fc625d0"
   },
   "q16_metric": {
     "id": "q16_metric",
@@ -143,7 +147,7 @@
     "description": "Q16 is a binary classifier used to determine whether an image is inappropriate (https://github.com/ml-research/Q16)",
     "endpoints": [],
     "configurations": {},
-    "hash": "a6403d2a6ea7f732"
+    "hash": "bd6b450dc92e5395"
   },
   "nudenet_metric": {
     "id": "nudenet_metric",
@@ -151,7 +155,7 @@
     "description": "NudeNet is a classifier used to deduce probabilities of exposed body parts in images.",
     "endpoints": [],
     "configurations": {},
-    "hash": "eaf9b4a52bf23b58"
+    "hash": "d46766cd42d0a97e"
   },
   "genderbias_metric": {
     "id": "genderbias_metric",
@@ -159,6 +163,6 @@
     "description": "This metric uses a CLIP based gender classifier to determine the proportion of females returning a score between 0 and 0.5. score = |female_frac - 0.5|",
     "endpoints": [],
     "configurations": {},
-    "hash": "db4ab533d45ca892"
+    "hash": "eabd08a995abff85"
   }
 }

--- a/metrics/exactstrmatch.py
+++ b/metrics/exactstrmatch.py
@@ -14,6 +14,8 @@ class ExactStrMatch(MetricInterface):
             " or multiple expected target."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -24,15 +26,13 @@ class ExactStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ExactStrMatch class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/exactstrmatch.py
+++ b/metrics/exactstrmatch.py
@@ -26,7 +26,6 @@ class ExactStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ExactStrMatch class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/flagjudgeannotator.py
+++ b/metrics/flagjudgeannotator.py
@@ -11,6 +11,8 @@ from moonshot.src.utils.timeit import timeit
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
+DEFAULT_EVALUATION_MODEL = "flageval-flagjudge"
+
 
 class FlagJudgeAnnotator(MetricInterface):
     def __init__(self):
@@ -18,6 +20,8 @@ class FlagJudgeAnnotator(MetricInterface):
         self.name = "FlagJudge Annotator"
         self.description = "Calculates the number of correct response using FlagJudge (A judge model from FlagEval Group)."  # noqa: E501
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [DEFAULT_EVALUATION_MODEL])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -28,15 +32,13 @@ class FlagJudgeAnnotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the FlagJudgeAnnotator class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/flagjudgeannotator.py
+++ b/metrics/flagjudgeannotator.py
@@ -32,7 +32,6 @@ class FlagJudgeAnnotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the FlagJudgeAnnotator class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/genderbias_metric.py
+++ b/metrics/genderbias_metric.py
@@ -48,7 +48,6 @@ class GenderBiasScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the GenderBiasScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/genderbias_metric.py
+++ b/metrics/genderbias_metric.py
@@ -25,6 +25,8 @@ class GenderBiasScore(MetricInterface):
             0.5  # reference fraction to compare gender distribution with
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
         self.clip_score_fn = partial(
             clip_score, model_name_or_path="openai/clip-vit-base-patch16"
         )
@@ -46,15 +48,13 @@ class GenderBiasScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the GenderBiasScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     def _is_female(self, img_path: str) -> bool:

--- a/metrics/gpt4annotator.py
+++ b/metrics/gpt4annotator.py
@@ -29,7 +29,6 @@ class GPT4Annotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the GPT4Annotator class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/gpt4annotator.py
+++ b/metrics/gpt4annotator.py
@@ -8,6 +8,8 @@ from moonshot.src.connectors_endpoints.connector_endpoint import ConnectorEndpoi
 from moonshot.src.metrics.metric_interface import MetricInterface
 from moonshot.src.utils.timeit import timeit
 
+DEFAULT_EVALUATION_MODEL = "llm-judge-openai-gpt4-annotator"
+
 
 class GPT4Annotator(MetricInterface):
     def __init__(self):
@@ -15,6 +17,8 @@ class GPT4Annotator(MetricInterface):
         self.name = "GPT4 Annotator"
         self.description = "Calculates the number of refused response using GPT4."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [DEFAULT_EVALUATION_MODEL])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -25,15 +29,13 @@ class GPT4Annotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the GPT4Annotator class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/leakagerate.py
+++ b/metrics/leakagerate.py
@@ -15,6 +15,8 @@ class LeakageRate(MetricInterface):
             "Leakage Rate will compare the LCS between two string - Output and Target."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -25,15 +27,13 @@ class LeakageRate(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LeakageRate class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/leakagerate.py
+++ b/metrics/leakagerate.py
@@ -27,7 +27,6 @@ class LeakageRate(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LeakageRate class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/lionguardclassifier.py
+++ b/metrics/lionguardclassifier.py
@@ -10,6 +10,8 @@ from moonshot.src.metrics.metric_interface import MetricInterface
 from moonshot.src.utils.timeit import timeit
 from transformers import AutoModel, AutoTokenizer
 
+DEFAULT_GRADING_CLASSIFIER = "toxic"
+
 
 class LionGuardClassifier(MetricInterface):
     def __init__(self):
@@ -20,6 +22,10 @@ class LionGuardClassifier(MetricInterface):
             "It can calculate the number of toxic sentences detected. "
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints")
+        self.configurations = self.metric_config.get(
+            "configurations", {"grading_classifier": DEFAULT_GRADING_CLASSIFIER}
+        )
 
     @timeit
     def get_metadata(self) -> dict | None:
@@ -31,15 +37,13 @@ class LionGuardClassifier(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LionGuardClassifier class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     # Timeit is a decorator that allows
@@ -61,7 +65,8 @@ class LionGuardClassifier(MetricInterface):
             dict: A dictionary containing my results
         """
         # threshold - bar to set in order to determine toxicity
-        grading_classifier = self.metric_config["grading_classifier"]
+        grading_classifier = self.configurations["grading_classifier"]
+
         repo_id = "govtech/lionguard-v1"
         config = {
             "description": "Binary classifier on harmful text in Singapore context",

--- a/metrics/lionguardclassifier.py
+++ b/metrics/lionguardclassifier.py
@@ -22,7 +22,7 @@ class LionGuardClassifier(MetricInterface):
             "It can calculate the number of toxic sentences detected. "
         )
         self.metric_config = self.get_metrics_configuration(self.id)
-        self.endpoints = self.metric_config.get("endpoints")
+        self.endpoints = self.metric_config.get("endpoints", [])
         self.configurations = self.metric_config.get(
             "configurations", {"grading_classifier": DEFAULT_GRADING_CLASSIFIER}
         )
@@ -37,7 +37,6 @@ class LionGuardClassifier(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LionGuardClassifier class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/llamaguardannotator.py
+++ b/metrics/llamaguardannotator.py
@@ -29,7 +29,6 @@ class LlamaGuardAnnotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LlamaGuardAnnotator class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/llamaguardannotator.py
+++ b/metrics/llamaguardannotator.py
@@ -8,6 +8,8 @@ from moonshot.src.connectors_endpoints.connector_endpoint import ConnectorEndpoi
 from moonshot.src.metrics.metric_interface import MetricInterface
 from moonshot.src.utils.timeit import timeit
 
+DEFAULT_EVALUATION_MODEL = "together-llama-guard-7b-assistant"
+
 
 class LlamaGuardAnnotator(MetricInterface):
     def __init__(self):
@@ -15,6 +17,8 @@ class LlamaGuardAnnotator(MetricInterface):
         self.name = "LlamaGuard Annotator"
         self.description = "Calculates the number of safe, unsafe and unknown response by using LlamaGuard."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [DEFAULT_EVALUATION_MODEL])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -25,15 +29,13 @@ class LlamaGuardAnnotator(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the LlamaGuardAnnotator class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit
@@ -53,6 +55,7 @@ class LlamaGuardAnnotator(MetricInterface):
         Returns:
             dict: A dictionary containing the accuracy of the predicted results.
         """
+
         evaluation_model = [
             Connector.create(ConnectorEndpoint.read(ep_id))
             for ep_id in self.metric_config["endpoints"]

--- a/metrics/metrics_config.json
+++ b/metrics/metrics_config.json
@@ -4,6 +4,11 @@
             "together-llama-guard-7b-assistant"
         ]
     },
+    "flagjudgeannotator":{
+        "endpoints": [
+            "flageval-flagjudge"
+        ]
+    },    
     "gpt4annotator":{
         "endpoints": [
             "llm-judge-openai-gpt4-annotator"

--- a/metrics/metrics_config.json
+++ b/metrics/metrics_config.json
@@ -1,12 +1,4 @@
 {
-    "llamaguardannotator":{
-        "endpoints": [
-            "together-llama-guard-7b-assistant"
-        ]
-    },
-    "lionguardclassifier":{
-            "grading_classifier": "toxic"
-    },    
     "flagjudgeannotator":{
         "endpoints": [
             "flageval-flagjudge"
@@ -15,6 +7,16 @@
     "gpt4annotator":{
         "endpoints": [
             "llm-judge-openai-gpt4-annotator"
+        ]
+    },
+    "lionguardclassifier":{
+        "configurations":{
+            "grading_classifier": "toxic"
+        }               
+    },
+    "llamaguardannotator":{
+        "endpoints": [
+            "together-llama-guard-7b-assistant"
         ]
     },
     "samplemetric":{

--- a/metrics/metrics_config.json
+++ b/metrics/metrics_config.json
@@ -4,6 +4,9 @@
             "together-llama-guard-7b-assistant"
         ]
     },
+    "lionguardclassifier":{
+            "grading_classifier": "toxic"
+    },    
     "flagjudgeannotator":{
         "endpoints": [
             "flageval-flagjudge"

--- a/metrics/nudenet_metric.py
+++ b/metrics/nudenet_metric.py
@@ -18,6 +18,9 @@ class NudeNetScore(MetricInterface):
         self.name = "NudeNetMetric"
         self.description = "NudeNet is a classifier used to deduce probabilities of exposed body parts in images."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
+
         self.nude_detector = NudeDetector()
         self.nude_detector_nude_classes = [
             "BUTTOCKS_EXPOSED",
@@ -36,15 +39,13 @@ class NudeNetScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the NudeNetScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     def _is_nude(self, img_path: str) -> bool:

--- a/metrics/nudenet_metric.py
+++ b/metrics/nudenet_metric.py
@@ -39,7 +39,6 @@ class NudeNetScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the NudeNetScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/q16_metric.py
+++ b/metrics/q16_metric.py
@@ -38,7 +38,6 @@ class Q16Score(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the Q16Score class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/q16_metric.py
+++ b/metrics/q16_metric.py
@@ -23,6 +23,8 @@ class Q16Score(MetricInterface):
         self.name = "Q16Metric"
         self.description = "Q16 is a binary classifier used to determine whether an image is inappropriate (https://github.com/ml-research/Q16)"  # noqa: E501
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
         self.model = CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
         self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
         self.soft_prompts = self._load_soft_prompts()
@@ -36,15 +38,13 @@ class Q16Score(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the Q16Score class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     def _load_soft_prompts(self) -> torch.Tensor:

--- a/metrics/readabilityscore.py
+++ b/metrics/readabilityscore.py
@@ -12,6 +12,8 @@ class ReadabilityScore(MetricInterface):
         self.name = "ReadabilityScore"
         self.description = "ReadabilityScore uses Flesch Reading Ease to compute the complexity of the output"
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -22,15 +24,13 @@ class ReadabilityScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ReadabilityScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/readabilityscore.py
+++ b/metrics/readabilityscore.py
@@ -24,7 +24,6 @@ class ReadabilityScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ReadabilityScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/relaxstrmatch.py
+++ b/metrics/relaxstrmatch.py
@@ -32,7 +32,6 @@ class RelaxStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the RelaxStrMatch class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/relaxstrmatch.py
+++ b/metrics/relaxstrmatch.py
@@ -20,6 +20,8 @@ class RelaxStrMatch(MetricInterface):
             "model with the expected target."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -30,15 +32,13 @@ class RelaxStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the RelaxStrMatch class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/reverseexactstrmatch.py
+++ b/metrics/reverseexactstrmatch.py
@@ -23,7 +23,6 @@ class ReverseExactStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ReverseExactStrMatch class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/reverseexactstrmatch.py
+++ b/metrics/reverseexactstrmatch.py
@@ -11,6 +11,8 @@ class ReverseExactStrMatch(MetricInterface):
         self.name = "ReverseExactStrMatch"
         self.description = "ReverseExactStrMatch will compare the output from language model with the expected target."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -21,15 +23,13 @@ class ReverseExactStrMatch(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ReverseExactStrMatch class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/rougescorer.py
+++ b/metrics/rougescorer.py
@@ -16,6 +16,8 @@ class RougeScorer(MetricInterface):
         self.name = "RougeScorer"
         self.description = "RougeScorer returns the various rouge scores."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -26,15 +28,13 @@ class RougeScorer(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the RougeScorer class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/rougescorer.py
+++ b/metrics/rougescorer.py
@@ -28,7 +28,6 @@ class RougeScorer(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the RougeScorer class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/samplemetric.py
+++ b/metrics/samplemetric.py
@@ -22,6 +22,8 @@ class SampleMetric(MetricInterface):
         self.name = "SampleMetric"
         self.description = "Sample Metric will provide examples on connecting to LLMs."
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     # Timeit is a decorator that allows you to see how much time it is needed to run this method.
     @timeit
@@ -36,15 +38,13 @@ class SampleMetric(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the SampleMetric class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     # Timeit is a decorator that allows you to see how much time it is needed to run this method.

--- a/metrics/samplemetric.py
+++ b/metrics/samplemetric.py
@@ -38,7 +38,6 @@ class SampleMetric(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the SampleMetric class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/spelling.py
+++ b/metrics/spelling.py
@@ -33,7 +33,6 @@ class SpellingScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the SpellingScore class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/spelling.py
+++ b/metrics/spelling.py
@@ -21,6 +21,8 @@ class SpellingScore(MetricInterface):
             "form the original word before comparing to known words in a word frequency list."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -31,15 +33,13 @@ class SpellingScore(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the SpellingScore class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit

--- a/metrics/toxicity-classifier.py
+++ b/metrics/toxicity-classifier.py
@@ -27,7 +27,6 @@ class ToxicityClassifier(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ToxicityClassifier class, or None if not applicable.
         """
-
         return {
             "id": self.id,
             "name": self.name,

--- a/metrics/toxicity-classifier.py
+++ b/metrics/toxicity-classifier.py
@@ -15,6 +15,8 @@ class ToxicityClassifier(MetricInterface):
             "and calculate the number of toxic sentence detected."
         )
         self.metric_config = self.get_metrics_configuration(self.id)
+        self.endpoints = self.metric_config.get("endpoints", [])
+        self.configurations = self.metric_config.get("configurations", {})
 
     def get_metadata(self) -> dict | None:
         """
@@ -25,15 +27,13 @@ class ToxicityClassifier(MetricInterface):
             dict | None: A dictionary containing the 'id', 'name', 'description', 'endpoints' 'and configurations'
             of the ToxicityClassifier class, or None if not applicable.
         """
-        endpoints = self.metric_config.get("endpoints", [])
-        configurations = self.metric_config.get("configurations", {})
 
         return {
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "endpoints": endpoints,
-            "configurations": configurations,
+            "endpoints": self.endpoints,
+            "configurations": self.configurations,
         }
 
     @timeit


### PR DESCRIPTION
## Description

Added missing metric config (flageval and lionguard) back to metrics_config.json

## Motivation and Context

-

## Type of Change
A bug fix

## How to Test

1. activate cli 
2. to test flageval: run `run_recipe "my new recipe runner" "['clcc']" "['openai-gpt35-turbo']" -n 1 -r 1 -s "You are an intelligent AI" `
3. to test lionguard, you can use the same recipe clcc but change the metric name to `lionguardclassifier`

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [x]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [x]  I have followed the project's coding conventions and style guidelines.
- [x]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [x]  I have performed a self-review of my own code.
- [x]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

-

## Additional Notes

-

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>