### PR TITLE
fix bug on model rebuilding

### DIFF
--- a/runners-modules/benchmarking.py
+++ b/runners-modules/benchmarking.py
@@ -1002,3 +1002,4 @@ class PromptArguments(BaseModel):
             random_seed=cache_record[12],
             system_prompt=cache_record[13],
         )
+PromptArguments.model_rebuild()

--- a/runners-modules/redteaming.py
+++ b/runners-modules/redteaming.py
@@ -417,3 +417,4 @@ class RedTeamingPromptArguments(BaseModel):
             "duration": str(self.connector_prompt.duration),
             "start_time": self.start_time,
         }
+RedTeamingPromptArguments.model_rebuild()


### PR DESCRIPTION
## Description

While running the jupyter notebook cells, when it comes to run_recipe it will throw the following error:
```
2024-11-27 16:53:54,017 [INFO][runner.py::run_recipes(354)] [Runner] math-recipe - Running benchmark recipe run...
2024-11-27 16:53:54,169 [INFO][benchmarking.py::generate(156)] [Benchmarking] Running recipes (['math-questions'])...
2024-11-27 16:53:54,170 [INFO][benchmarking.py::generate(160)] [Benchmarking] Running recipe math-questions... (1/1)
2024-11-27 16:53:54,191 [ERROR][run_progress.py::notify_error(47)] [Benchmarking] Error during generator pipeline execution: `PromptArguments` is not fully defined; you should define `ConnectorPromptArguments`, then call `PromptArguments.model_rebuild()`.

For further information visit https://errors.pydantic.dev/2.9/u/class-not-fully-defined
2024-11-27 16:53:54,192 [INFO][benchmarking.py::generate(190)] [Benchmarking] Run took 0.0234s
2024-11-27 16:53:54,193 [INFO][benchmarking.py::generate(245)] [Benchmarking] Preparing results took 0.0000s
2024-11-27 16:53:54,199 [INFO][benchmarking-result.py::generate(58)] [BenchmarkingResult] Generate results took 0.0059s
2024-11-27 16:53:54,201 [INFO][runner.py::run_recipes(380)] [Runner] math-recipe - Benchmark recipe run completed.
```

## Motivation and Context

Fix bug

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
<!-- - chore: Routine tasks, maintenance, or tooling changes -->
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test

Please follow the jupyter notebook instructions and re-run all the cells to see if this still appears.

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [ ]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [ ]  I have performed a self-review of my own code.
- [ ]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>