### PR TITLE
[Release] 0.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "moonshot-data"
-version = "0.7.5"
+version = "0.7.6"
 authors = [
     { name="The Moonshot Team", email="our.moonshot.team@gmail.com" }
 ]
@@ -17,7 +17,7 @@ classifiers = [
 
 [tool.poetry]
 name = "moonshot-data"
-version = "0.7.5"
+version = "0.7.6"
 description = "A collection of data(e.g. llm connectors, benchmark tests) that can be used with the Moonshot toolkit."
 authors = ["The Moonshot Team <our.moonshot.team@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Description

[WS-303] Fix cmd2 version to >=2.5.11 and <3.0.0
 
## Motivation and Context

aiverify-moonshot package on Pypi will resolve cmd2 to v3.10, which broke Interactive CLI feature. 

## Type of Change

<!-- Select the appropriate type of change: -->
<!-- - feat: A new feature -->
- fix: A bug fix
- chore: Routine tasks, maintenance, or tooling changes
<!-- - docs: Documentation updates -->
<!-- - style: Code style changes (e.g., formatting, indentation) -->
<!-- - refactor: Code refactoring without changes in functionality -->
<!-- - test: Adding or modifying tests -->
<!-- - perf: Performance improvements -->
<!-- - ci: Changes to the CI/CD configuration or scripts -->
<!-- - other: Other changes that don't fit into the above categories -->

## How to Test
* `poetry lock`,  `poetry export -f requirements.txt` for moonshot and moonshot-data, then compared requirements.txt to ensure cmd2 version is not >=3.0.0:
  1. `pip install -r requirements.txt` moonshot first, then moonshot-data.
  2. `pip install -r requirements.txt` both moonshot and moonshot-data at the same time.
  3. `python -m build` to generate aiverify-moonshot wheel file, `pip install the aiverify-moonshot` wheel file, and then `pip install -r requirements.txt` for moonshot-data.
* Locally launched Interactive CLI and Web UI, and ran benchmark and red teaming. 

## Checklist

Please check all the boxes that apply to this pull request using "x":

- [X]  I have tested the changes locally and verified that they work as expected.
- [ ]  I have added or updated the necessary documentation (README, API docs, etc.).
- [ ]  I have added appropriate unit tests or functional tests for the changes made.
- [ ]  I have followed the project's coding conventions and style guidelines.
- [ ]  I have rebased my branch onto the latest commit of the main branch.
- [ ]  I have squashed or reorganized my commits into logical units.
- [ ]  I have added any necessary dependencies or packages to the project's build configuration.
- [X]  I have performed a self-review of my own code.
- [X]  I have read, understood and agree to the Developer Certificate of Origin below, which this project utilises.

## Screenshots (if applicable)

[If the changes involve visual modifications, include screenshots or GIFs that demonstrate the changes.]

## Additional Notes

[Add any additional information or context that might be relevant to reviewers.]

<details>
  <summary>Developer Certificate of Origin</summary>

 ```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
 ```
</details>